### PR TITLE
Fix performance of int over axis

### DIFF
--- a/py4incompact3d/tools/misc.py
+++ b/py4incompact3d/tools/misc.py
@@ -81,7 +81,7 @@ def int_over_axis(mesh, x, axis):
         # Transpose to Y
         phiX = py4incompact3d.postprocess.Field()
         phiX.new(mesh, pencil=0)
-        phiX.data[0][:][:][:] = x[:][:][:]
+        phiX.data[0][:,:,:] = x[:,:,:]
 
         phiY = py4incompact3d.postprocess.Field()
         phiY.new(mesh, pencil=1)
@@ -128,26 +128,23 @@ def int_over_axis(mesh, x, axis):
             # Transpose from Z
             for i in range(s.shape[0]):
                 for j in range(s.shape[1]):
-                    for k in range(phi.shape[2]):
-                        phiZ.data[0][i][j][k] = s[i][j]
+                        phiZ.data[0][i,j,:] = s[i,j]
 
             phiY.data[0] = parallel.transpose(phiZ.data[0], "zy", phiY.data[0])
 
         else:
             for i in range(s.shape[0]):
-                for j in range(phi.shape[1]):
-                    for k in range(s.shape[1]):
-                        phiY.data[0][i][j][k] = s[i][k]
+                for k in range(s.shape[1]):
+                    phiY.data[0][i,:,k] = s[i,k]
 
         # Transpose from Y
         phiX.data[0] = parallel.transpose(phiY.data[0], "yx", phiX.data[0])
         phi = phiX.data[0]
 
     else:
-        for i in range(phi.shape[0]):
-            for j in range(s.shape[0]):
-                for k in range(s.shape[1]):
-                    phi[i][j][k] = s[j][k]
+        for j in range(s.shape[0]):
+            for k in range(s.shape[1]):
+                phi[:,j,k] = s[j,k]
 
     return phi
 


### PR DESCRIPTION
Replace Python loops with numpy-vectorised operations, also avoids creating temporary arrays